### PR TITLE
Allow for DPad input be gotten via Button methods, etc.

### DIFF
--- a/XboxCtrlrInput/Assets/Plugins/x86/XInputDotNetPure.dll.meta
+++ b/XboxCtrlrInput/Assets/Plugins/x86/XInputDotNetPure.dll.meta
@@ -9,6 +9,47 @@ PluginImporter:
     Any:
       enabled: 1
       settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        CPU: x86
+        DefaultValueInitialized: true
+    Linux:
+      enabled: 1
+      settings:
+        CPU: x86
+    Linux64:
+      enabled: 0
+      settings:
+        CPU: None
+    LinuxUniversal:
+      enabled: 0
+      settings:
+        CPU: x86
+    OSXIntel:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+    OSXIntel64:
+      enabled: 0
+      settings:
+        CPU: None
+    OSXUniversal:
+      enabled: 0
+      settings:
+        CPU: x86
+    Win:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+    Win64:
+      enabled: 0
+      settings:
+        CPU: None
+    WindowsStoreApps:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/XboxCtrlrInput/Assets/Plugins/x86_64/XInputDotNetPure.dll.meta
+++ b/XboxCtrlrInput/Assets/Plugins/x86_64/XInputDotNetPure.dll.meta
@@ -9,6 +9,47 @@ PluginImporter:
     Any:
       enabled: 1
       settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+    Linux:
+      enabled: 0
+      settings:
+        CPU: None
+    Linux64:
+      enabled: 1
+      settings:
+        CPU: x86_64
+    LinuxUniversal:
+      enabled: 0
+      settings:
+        CPU: x86_64
+    OSXIntel:
+      enabled: 0
+      settings:
+        CPU: None
+    OSXIntel64:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+    OSXUniversal:
+      enabled: 0
+      settings:
+        CPU: x86_64
+    Win:
+      enabled: 0
+      settings:
+        CPU: None
+    Win64:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+    WindowsStoreApps:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/XboxCtrlrInput/Assets/XboxCtrlrInput/Example/Test Level Scripts/MovePlayer.cs
+++ b/XboxCtrlrInput/Assets/XboxCtrlrInput/Example/Test Level Scripts/MovePlayer.cs
@@ -7,7 +7,7 @@ public class MovePlayer : MonoBehaviour
 	
 	public float jumpImpulse;
 	public float maxMoveSpeed;
-	public int playerNumber = 0;
+	public XboxController controller;
 	
 	public Material matRed;
 	public Material matGreen;
@@ -38,14 +38,12 @@ public class MovePlayer : MonoBehaviour
 	// Start
 	void Start () 
 	{
-		playerNumber = Mathf.Clamp(playerNumber, 1, 4);
-		
-		switch(playerNumber)
+		switch(controller)
 		{
-			case 1: GetComponent<Renderer>().material = matRed; break;
-			case 2: GetComponent<Renderer>().material = matGreen; break;
-			case 3: GetComponent<Renderer>().material = matBlue; break;
-			case 4: GetComponent<Renderer>().material = matYellow; break;
+			case XboxController.First: GetComponent<Renderer>().material = matRed; break;
+			case XboxController.Second: GetComponent<Renderer>().material = matGreen; break;
+			case XboxController.Third: GetComponent<Renderer>().material = matBlue; break;
+			case XboxController.Fourth: GetComponent<Renderer>().material = matYellow; break;
 		}
 		
 		newPosition = transform.position;
@@ -79,14 +77,14 @@ public class MovePlayer : MonoBehaviour
 		GameObject bulletReference = null;
 		
 		// Jump (Left Stick)
-		if(XCI.GetButtonDown(XboxButton.LeftStick, playerNumber) && canJump)
+		if(XCI.GetButtonDown(XboxButton.LeftStick, controller) && canJump)
 		{
 			canJump = false;
 			GetComponent<Rigidbody>().AddRelativeForce(0.0f, jumpImpulse, 0.0f, ForceMode.Impulse);
 		}
 		
 		// Slam (Right Stick)
-		if(XCI.GetButtonDown(XboxButton.RightStick, playerNumber) && !canJump)
+		if(XCI.GetButtonDown(XboxButton.RightStick, controller) && !canJump)
 		{
 			GetComponent<Rigidbody>().AddRelativeForce(0.0f, (-jumpImpulse * 1.5f), 0.0f, ForceMode.Impulse);
 		}
@@ -100,22 +98,22 @@ public class MovePlayer : MonoBehaviour
 		
 		if(bulletTimer <= 0.0f)
 		{
-			if(XCI.GetButton(XboxButton.A, playerNumber))
+			if(XCI.GetButton(XboxButton.A, controller))
 			{
 				Instantiate(laserAPrefab, transform.position, laserAPrefab.transform.rotation);
 				bulletTimer = MAX_BUL_TME;
 			}
-			if(XCI.GetButton(XboxButton.B, playerNumber))
+			if(XCI.GetButton(XboxButton.B, controller))
 			{
 				Instantiate(laserBPrefab, transform.position, laserBPrefab.transform.rotation);
 				bulletTimer = MAX_BUL_TME;
 			}
-			if(XCI.GetButton(XboxButton.X, playerNumber))
+			if(XCI.GetButton(XboxButton.X, controller))
 			{
 				Instantiate(laserXPrefab, transform.position, laserXPrefab.transform.rotation);
 				bulletTimer = MAX_BUL_TME;
 			}
-			if(XCI.GetButton(XboxButton.Y, playerNumber))
+			if(XCI.GetButton(XboxButton.Y, controller))
 			{
 				Instantiate(laserYPrefab, transform.position, laserYPrefab.transform.rotation);
 				bulletTimer = MAX_BUL_TME;
@@ -124,8 +122,8 @@ public class MovePlayer : MonoBehaviour
 		
 		// Left stick movement
 		newPosition = transform.position;
-		float axisX = XCI.GetAxis(XboxAxis.LeftStickX, playerNumber);
-		float axisY = XCI.GetAxis(XboxAxis.LeftStickY, playerNumber);
+		float axisX = XCI.GetAxis(XboxAxis.LeftStickX, controller);
+		float axisY = XCI.GetAxis(XboxAxis.LeftStickY, controller);
 		float newPosX = newPosition.x + (axisX * maxMoveSpeed * Time.deltaTime);
 		float newPosZ = newPosition.z + (axisY * maxMoveSpeed * Time.deltaTime);
 		newPosition = new Vector3(newPosX, transform.position.y, newPosZ);
@@ -134,8 +132,8 @@ public class MovePlayer : MonoBehaviour
 		
 		// Right stick movement
 		newPosition = transform.position;
-		axisX = XCI.GetAxis(XboxAxis.RightStickX, playerNumber);
-		axisY = XCI.GetAxis(XboxAxis.RightStickY, playerNumber);
+		axisX = XCI.GetAxis(XboxAxis.RightStickX, controller);
+		axisY = XCI.GetAxis(XboxAxis.RightStickY, controller);
 		newPosX = newPosition.x + (axisX * maxMoveSpeed * 0.3f * Time.deltaTime);
 		newPosZ = newPosition.z + (axisY * maxMoveSpeed * 0.3f * Time.deltaTime);
 		newPosition = new Vector3(newPosX, transform.position.y, newPosZ);
@@ -161,7 +159,7 @@ public class MovePlayer : MonoBehaviour
 		}
 		if(dpUpBulletTimer <= 0.0f)
 		{
-			if(XCI.GetDPad(XboxDPad.Up, playerNumber))
+			if(XCI.GetDPad(XboxDPad.Up, controller))
 			{
 				bulletReference = Instantiate(laserBumpPrefab, transform.position, laserYPrefab.transform.rotation) as GameObject;
 				bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 1.0f);
@@ -170,7 +168,7 @@ public class MovePlayer : MonoBehaviour
 		}
 		if(dpDownBulletTimer <= 0.0f)
 		{
-			if(XCI.GetDPad(XboxDPad.Down, playerNumber))
+			if(XCI.GetDPad(XboxDPad.Down, controller))
 			{
 				bulletReference = Instantiate(laserBumpPrefab, transform.position, laserAPrefab.transform.rotation) as GameObject;
 				bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 1.0f);
@@ -179,7 +177,7 @@ public class MovePlayer : MonoBehaviour
 		}
 		if(dpLeftBulletTimer <= 0.0f)
 		{
-			if(XCI.GetDPad(XboxDPad.Left, playerNumber))
+			if(XCI.GetDPad(XboxDPad.Left, controller))
 			{
 				bulletReference = Instantiate(laserBumpPrefab, transform.position, laserXPrefab.transform.rotation) as GameObject;
 				bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 1.0f);
@@ -188,7 +186,7 @@ public class MovePlayer : MonoBehaviour
 		}
 		if(dpRightBulletTimer <= 0.0f)
 		{
-			if(XCI.GetDPad(XboxDPad.Right, playerNumber))
+			if(XCI.GetDPad(XboxDPad.Right, controller))
 			{
 				bulletReference = Instantiate(laserBumpPrefab, transform.position, laserBPrefab.transform.rotation) as GameObject;
 				bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 1.0f);
@@ -200,30 +198,30 @@ public class MovePlayer : MonoBehaviour
 		// Trigger input
 		float trigSclX = triggerLeftPrefab.transform.localScale.x;
 		float trigSclZ = triggerLeftPrefab.transform.localScale.z;
-		float leftTrigHeight = MAX_TRG_SCL * (1.0f - XCI.GetAxis(XboxAxis.LeftTrigger, playerNumber));
-		float rightTrigHeight = MAX_TRG_SCL * (1.0f - XCI.GetAxis(XboxAxis.RightTrigger, playerNumber));
+		float leftTrigHeight = MAX_TRG_SCL * (1.0f - XCI.GetAxis(XboxAxis.LeftTrigger, controller));
+		float rightTrigHeight = MAX_TRG_SCL * (1.0f - XCI.GetAxis(XboxAxis.RightTrigger, controller));
 		triggerLeftPrefab.transform.localScale = new Vector3(trigSclX, leftTrigHeight, trigSclZ);
 		triggerRightPrefab.transform.localScale = new Vector3(trigSclX, rightTrigHeight, trigSclZ);
 		
 		
 		// Bumper input
-		if(XCI.GetButtonDown(XboxButton.LeftBumper, playerNumber))
+		if(XCI.GetButtonDown(XboxButton.LeftBumper, controller))
 		{
 			Instantiate(laserBumpPrefab, triggerLeftPrefab.transform.position, laserBumpPrefab.transform.rotation);
 		}
-		if(XCI.GetButtonDown(XboxButton.RightBumper, playerNumber))
+		if(XCI.GetButtonDown(XboxButton.RightBumper, controller))
 		{
 			Instantiate(laserBumpPrefab, triggerRightPrefab.transform.position, laserBumpPrefab.transform.rotation);
 		}
 		
 		
 		// Start and back, same as bumpers but smaller bullets
-		if(XCI.GetButtonUp(XboxButton.Back, playerNumber))
+		if(XCI.GetButtonUp(XboxButton.Back, controller))
 		{
 			bulletReference = Instantiate(laserBumpPrefab, triggerLeftPrefab.transform.position, laserBumpPrefab.transform.rotation) as GameObject;
 			bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
 		}
-		if(XCI.GetButtonUp(XboxButton.Start, playerNumber))
+		if(XCI.GetButtonUp(XboxButton.Start, controller))
 		{
 			bulletReference = Instantiate(laserBumpPrefab, triggerRightPrefab.transform.position, laserBumpPrefab.transform.rotation) as GameObject;
 			bulletReference.transform.localScale = new Vector3(0.1f, 0.1f, 0.1f);
@@ -260,13 +258,13 @@ public class MovePlayer : MonoBehaviour
 	// Gizmo Drawing
 	void OnDrawGizmos()
 	{
-		switch (playerNumber)
+		switch (controller)
 		{
-			case 1:		Gizmos.color = Color.red; break;
-			case 2:		Gizmos.color = Color.green; break;
-			case 3:		Gizmos.color = Color.blue; break;
-			case 4:		Gizmos.color = Color.yellow; break;
-			default:	Gizmos.color = Color.white; break;
+			case XboxController.First:  Gizmos.color = Color.red; break;
+			case XboxController.Second: Gizmos.color = Color.green; break;
+			case XboxController.Third:  Gizmos.color = Color.blue; break;
+			case XboxController.Fourth: Gizmos.color = Color.yellow; break;
+			default:                    Gizmos.color = Color.white; break;
 		}
 		
 		Gizmos.color = new Color(Gizmos.color.r, Gizmos.color.g, Gizmos.color.b, 0.5f);

--- a/XboxCtrlrInput/Assets/XboxCtrlrInput/Example/XCI_Test_Room.unity
+++ b/XboxCtrlrInput/Assets/XboxCtrlrInput/Example/XCI_Test_Room.unity
@@ -8,25 +8,25 @@ SceneSettings:
   m_PVSPortalsArray: []
   m_OcclusionBakeSettings:
     smallestOccluder: 5
-    smallestHole: .25
+    smallestHole: 0.25
     backfaceThreshold: 100
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 6
   m_Fog: 0
-  m_FogColor: {r: .5, g: .5, b: .5, a: 1}
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
-  m_FogDensity: .00999999978
+  m_FogDensity: 0.01
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
-  m_AmbientSkyColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
-  m_AmbientEquatorColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
-  m_AmbientGroundColor: {r: .200000003, g: .200000003, b: .200000003, a: 1}
+  m_AmbientSkyColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_AmbientEquatorColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_AmbientGroundColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 3
   m_SkyboxMaterial: {fileID: 0}
-  m_HaloStrength: .5
+  m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
   m_HaloTexture: {fileID: 0}
@@ -40,7 +40,7 @@ RenderSettings:
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 6
   m_GIWorkflowMode: 1
   m_LightmapsMode: 1
   m_GISettings:
@@ -66,7 +66,7 @@ LightmapSettings:
     m_FinalGather: 0
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
-  m_LightmapSnapshot: {fileID: 0}
+  m_LightingDataAsset: {fileID: 0}
   m_RuntimeCPUUsage: 25
 --- !u!196 &5
 NavMeshSettings:
@@ -74,15 +74,15 @@ NavMeshSettings:
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
-    agentRadius: .5
+    agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
-    agentClimb: .400000006
+    agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
     accuratePlacement: 0
     minRegionArea: 2
-    cellSize: .166666657
+    cellSize: 0.16666666
     manualCellSize: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &33521087
@@ -107,8 +107,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 33521087}
-  m_LocalRotation: {x: .408217937, y: -.234569728, z: .109381661, w: .875426114}
-  m_LocalPosition: {x: -16.3964233, y: 12.6382885, z: 2.14037228}
+  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.10938166, w: 0.8754261}
+  m_LocalPosition: {x: -16.396423, y: 12.6382885, z: 2.1403723}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1147984942}
@@ -123,7 +123,7 @@ Light:
   serializedVersion: 6
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: .5
+  m_Intensity: 0.5
   m_Range: 10
   m_SpotAngle: 30
   m_CookieSize: 10
@@ -131,8 +131,9 @@ Light:
     m_Type: 0
     m_Resolution: -1
     m_Strength: 1
-    m_Bias: .0500000007
-    m_NormalBias: .400000006
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -194,14 +195,14 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: .198529422, g: .198529422, b: .198529422, a: .0196078438}
+  m_BackGroundColor: {r: 0.19852942, g: 0.19852942, b: 0.19852942, a: 0.019607844}
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
     y: 0
     width: 1
     height: 1
-  near clip plane: .300000012
+  near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
   orthographic: 0
@@ -217,7 +218,7 @@ Camera:
   m_HDR: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
-  m_StereoSeparation: .0219999999
+  m_StereoSeparation: 0.022
   m_StereoMirrorMode: 0
 --- !u!4 &302288837
 Transform:
@@ -225,8 +226,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 302288832}
-  m_LocalRotation: {x: .393471748, y: 0, z: 0, w: .919336736}
-  m_LocalPosition: {x: 0, y: 11.9358768, z: -15.6521845}
+  m_LocalRotation: {x: 0.39347175, y: 0, z: 0, w: 0.91933674}
+  m_LocalPosition: {x: 0, y: 11.935877, z: -15.6521845}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1147984942}
@@ -278,6 +279,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 11400000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
+      propertyPath: controller
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
   m_IsPrefabParent: 0
@@ -326,6 +331,10 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 11400000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
       propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11400000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
+      propertyPath: controller
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -410,6 +419,10 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 11400000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
+      propertyPath: controller
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
   m_IsPrefabParent: 0
@@ -435,8 +448,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1213290086}
-  m_LocalRotation: {x: .707106829, y: 0, z: 0, w: .707106829}
-  m_LocalPosition: {x: -13.6796627, y: 13.7978592, z: -.710346222}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -13.679663, y: 13.797859, z: -0.7103462}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1147984942}
@@ -451,7 +464,7 @@ Light:
   serializedVersion: 6
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: .200000003
+  m_Intensity: 0.2
   m_Range: 10
   m_SpotAngle: 30
   m_CookieSize: 10
@@ -460,7 +473,8 @@ Light:
     m_Resolution: -1
     m_Strength: 1
     m_Bias: 0
-    m_NormalBias: .400000006
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -498,8 +512,8 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1373158983}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -11.7113647, z: 0}
-  m_LocalScale: {x: 100, y: .5, z: 100}
+  m_LocalPosition: {x: 0, y: -11.711365, z: 0}
+  m_LocalScale: {x: 100, y: 0.5, z: 100}
   m_Children: []
   m_Father: {fileID: 1147984942}
   m_RootOrder: 3
@@ -521,8 +535,10 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
@@ -589,6 +605,10 @@ Prefab:
       propertyPath: m_Name
       value: go_Player2
       objectReference: {fileID: 0}
+    - target: {fileID: 11400000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
+      propertyPath: controller
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 33442b9c472c1f04eb0c9bc977f6e379, type: 2}
   m_IsPrefabParent: 0
@@ -618,7 +638,7 @@ Transform:
   m_GameObject: {fileID: 2007729798}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 20, y: .5, z: 20}
+  m_LocalScale: {x: 20, y: 0.5, z: 20}
   m_Children: []
   m_Father: {fileID: 1147984942}
   m_RootOrder: 4
@@ -640,8 +660,10 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0

--- a/XboxCtrlrInput/Assets/XboxCtrlrInput/XboxCtrlrInput.cs
+++ b/XboxCtrlrInput/Assets/XboxCtrlrInput/XboxCtrlrInput.cs
@@ -7,6 +7,18 @@ namespace XboxCtrlrInput
 	// ================= Enumerations ==================== //
 	
 	/// <summary>
+	///     List of enumerated identifiers for Xbox controllers.
+	/// </summary>
+	public enum XboxController
+	{
+		All = 0,
+		First = 1,
+		Second = 2,
+		Third = 3,
+		Fourth = 4
+	}
+
+	/// <summary>
 	/// 	List of enumerated identifiers for Xbox buttons.
 	/// </summary>
 	public enum XboxButton
@@ -20,7 +32,11 @@ namespace XboxCtrlrInput
 		LeftStick,
 		RightStick,
 		LeftBumper,
-		RightBumper
+		RightBumper,
+		DPadUp,
+		DPadDown,
+		DPadLeft,
+		DPadRight
 	}
 	
 	/// <summary>
@@ -47,9 +63,33 @@ namespace XboxCtrlrInput
 		RightTrigger
 	}
 	
-	// ================= Class ==================== //
-	
-	public sealed class XCI 
+	// ================ Classes =================== //
+
+	public static class XboxButtonExtensions
+	{
+		public static bool IsDPad(this XboxButton button)
+		{
+			return (button == XboxButton.DPadUp ||
+				button == XboxButton.DPadDown ||
+				button == XboxButton.DPadLeft ||
+				button == XboxButton.DPadRight);
+		}
+
+		public static XboxDPad ToDPad(this XboxButton button)
+		{
+			if (button == XboxButton.DPadUp)
+				return XboxDPad.Up;
+			if (button == XboxButton.DPadDown)
+				return XboxDPad.Down;
+			if (button == XboxButton.DPadLeft)
+				return XboxDPad.Left;
+			if (button == XboxButton.DPadRight)
+				return XboxDPad.Right;
+			return default(XboxDPad);
+		}
+	}
+
+	public sealed class XCI
 	{
 		// ------------ Public Methods --------------- //
 		
@@ -63,6 +103,9 @@ namespace XboxCtrlrInput
 		/// </param>
 		public static bool GetButton(XboxButton button)
 		{
+			if (button.IsDPad())
+				return GetDPad(button.ToDPad());
+
 			if(OnWindowsNative())
 			{
 				if(!XInputStillInCurrFrame())
@@ -96,12 +139,18 @@ namespace XboxCtrlrInput
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the button.
 		/// </param>
-		public static bool GetButton(XboxButton button, int controllerNumber)
+		public static bool GetButton(XboxButton button, XboxController controller)
 		{
-			if(!IsControllerNumberValid(controllerNumber))  return false;
+			if (button.IsDPad())
+				return GetDPad(button.ToDPad(), controller);
+
+			if (controller == XboxController.All)
+				return GetButton(button);
+
+			int controllerNumber = (int)controller;
 			
 			if(OnWindowsNative())
 			{
@@ -139,6 +188,9 @@ namespace XboxCtrlrInput
 		/// </param>
 		public static bool GetButtonDown(XboxButton button)
 		{
+			if (button.IsDPad())
+				return GetDPadDown(button.ToDPad());
+
 			if(OnWindowsNative())
 			{
 				if(!XInputStillInCurrFrame())
@@ -175,13 +227,19 @@ namespace XboxCtrlrInput
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the button.
 		/// </param>
-		public static bool GetButtonDown(XboxButton button, int controllerNumber)
+		public static bool GetButtonDown(XboxButton button, XboxController controller)
 		{
-			if(!IsControllerNumberValid(controllerNumber))  return false;
-			
+			if (button.IsDPad())
+				return GetDPadDown(button.ToDPad(), controller);
+
+			if (controller == XboxController.All)
+				return GetButtonDown(button);
+
+			int controllerNumber = (int)controller;
+
 			if(OnWindowsNative())
 			{
 				if(!XInputStillInCurrFrame())
@@ -220,6 +278,9 @@ namespace XboxCtrlrInput
 		/// </param>
 		public static bool GetButtonUp(XboxButton button)
 		{
+			if (button.IsDPad())
+				return GetDPadUp(button.ToDPad());
+
 			if(OnWindowsNative())
 			{
 				if(Time.frameCount < 2)
@@ -261,13 +322,19 @@ namespace XboxCtrlrInput
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the button.
 		/// </param>
-		public static bool GetButtonUp(XboxButton button, int controllerNumber)
+		public static bool GetButtonUp(XboxButton button, XboxController controller)
 		{
-			if(!IsControllerNumberValid(controllerNumber))  return false;
-			
+			if (button.IsDPad())
+				return GetDPadUp(button.ToDPad(), controller);
+
+			if (controller == XboxController.All)
+				return GetButtonUp(button);
+
+			int controllerNumber = (int)controller;
+
 			if(OnWindowsNative())
 			{
 				if(Time.frameCount < 2)
@@ -369,11 +436,16 @@ namespace XboxCtrlrInput
 		/// <param name='padDirection'> 
 		/// 	An identifier for the specified D-Pad direction to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the D-Pad. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the D-Pad.
 		/// </param>
-		public static bool GetDPad(XboxDPad padDirection, int controllerNumber)
+		public static bool GetDPad(XboxDPad padDirection, XboxController controller)
 		{
+			if (controller == XboxController.All)
+				return GetDPad(padDirection);
+
+			int controllerNumber = (int)controller;
+
 			bool r = false;
 			
 			if(OnWindowsNative())
@@ -431,9 +503,6 @@ namespace XboxCtrlrInput
 		/// </summary>
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
-		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
 		/// </param>
 		public static bool GetDPadUp(XboxDPad padDirection)
 		{
@@ -494,12 +563,16 @@ namespace XboxCtrlrInput
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the button.
 		/// </param>
-		public static bool GetDPadUp(XboxDPad padDirection, int controllerNumber)
+		public static bool GetDPadUp(XboxDPad padDirection, XboxController controller)
 		{
-			
+			if (controller == XboxController.All)
+				return GetDPadUp(padDirection);
+
+			int controllerNumber = (int)controller;
+
 			bool r = false;
 			
 			if(OnWindowsNative())
@@ -555,9 +628,6 @@ namespace XboxCtrlrInput
 		/// </summary>
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
-		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
 		/// </param>
 		public static bool GetDPadDown(XboxDPad padDirection)
 		{
@@ -618,12 +688,16 @@ namespace XboxCtrlrInput
 		/// <param name='button'> 
 		/// 	Identifier for the Xbox button to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the button. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the button.
 		/// </param>
-		public static bool GetDPadDown(XboxDPad padDirection, int controllerNumber)
+		public static bool GetDPadDown(XboxDPad padDirection, XboxController controller)
 		{
-			
+			if (controller == XboxController.All)
+				return GetDPadDown(padDirection);
+
+			int controllerNumber = (int)controller;
+
 			bool r = false;
 			
 			if(OnWindowsNative())
@@ -720,11 +794,16 @@ namespace XboxCtrlrInput
 		/// <param name='axis'> 
 		/// 	An identifier for the specified Xbox axis to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the axis. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the axis.
 		/// </param>
-		public static float GetAxis(XboxAxis axis, int controllerNumber)
+		public static float GetAxis(XboxAxis axis, XboxController controller)
 		{
+			if (controller == XboxController.All)
+				return GetAxis(axis);
+
+			int controllerNumber = (int)controller;
+
 			float r = 0.0f;
 			
 			if(OnWindowsNative())
@@ -803,11 +882,16 @@ namespace XboxCtrlrInput
 		/// <param name='axis'> 
 		/// 	An identifier for the specified Xbox axis to be tested. 
 		/// </param>
-		/// <param name='controllerNumber'> 
-		/// 	An identifier for the specific controller on which to test the axis. An int between 1 and 4. 
+		/// <param name='controller'>
+		/// 	An identifier for the specific controller on which to test the axis.
 		/// </param>
-		public static float GetAxisRaw(XboxAxis axis, int controllerNumber)
+		public static float GetAxisRaw(XboxAxis axis, XboxController controller)
 		{
+			if (controller == XboxController.All)
+				return GetAxisRaw(axis);
+
+			int controllerNumber = (int)controller;
+
 			float r = 0.0f;
 			
 			if(OnWindowsNative())

--- a/XboxCtrlrInput/ProjectSettings/ClusterInputManager.asset
+++ b/XboxCtrlrInput/ProjectSettings/ClusterInputManager.asset
@@ -1,0 +1,6 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!236 &1
+ClusterInputManager:
+  m_ObjectHideFlags: 0
+  m_Inputs: []

--- a/XboxCtrlrInput/ProjectSettings/ProjectSettings.asset
+++ b/XboxCtrlrInput/ProjectSettings/ProjectSettings.asset
@@ -3,17 +3,18 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   AndroidProfiler: 0
   defaultScreenOrientation: 0
   targetDevice: 2
-  targetResolution: 0
+  useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: JibranSyed
   productName: Xbox360InputTest
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_ShowUnitySplashScreen: 1
+  m_VirtualRealitySplashScreen: {fileID: 0}
   defaultScreenWidth: 1024
   defaultScreenHeight: 768
   defaultScreenWidthWeb: 960
@@ -28,6 +29,7 @@ PlayerSettings:
   androidShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 2
+  iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
   allowedAutorotateToLandscapeRight: 1
@@ -54,15 +56,19 @@ PlayerSettings:
   xboxEnableKinectAutoTracking: 0
   xboxEnableFitness: 0
   visibleInBackground: 0
+  allowFullscreenSwitch: 1
   macFullscreenMode: 2
   d3d9FullscreenMode: 1
   d3d11FullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
+  xboxEnablePIXSampling: 0
   n3dsDisableStereoscopicView: 0
   n3dsEnableSharedListOpt: 1
   n3dsEnableVSync: 0
+  uiUse16BitDepthBuffer: 0
+  ignoreAlphaClear: 0
   xboxOneResolution: 0
   ps3SplashScreen: {fileID: 0}
   videoMemoryForVertexBuffers: 0
@@ -113,6 +119,7 @@ PlayerSettings:
   iPhoneTargetOSVersion: 22
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
+  uIRequiresFullScreen: 1
   uIStatusBarHidden: 1
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
@@ -126,6 +133,10 @@ PlayerSettings:
   iPadHighResPortraitSplashScreen: {fileID: 0}
   iPadLandscapeSplashScreen: {fileID: 0}
   iPadHighResLandscapeSplashScreen: {fileID: 0}
+  appleTVSplashScreen: {fileID: 0}
+  tvOSSmallIconLayers: []
+  tvOSLargeIconLayers: []
+  tvOSTopShelfImageLayers: []
   iOSLaunchScreenType: 0
   iOSLaunchScreenPortrait: {fileID: 0}
   iOSLaunchScreenLandscape: {fileID: 0}
@@ -135,6 +146,15 @@ PlayerSettings:
   iOSLaunchScreenFillPct: 1
   iOSLaunchScreenSize: 100
   iOSLaunchScreenCustomXibPath: 
+  iOSLaunchScreeniPadType: 0
+  iOSLaunchScreeniPadImage: {fileID: 0}
+  iOSLaunchScreeniPadBackgroundColor:
+    serializedVersion: 2
+    rgba: 0
+  iOSLaunchScreeniPadFillPct: 100
+  iOSLaunchScreeniPadSize: 100
+  iOSLaunchScreeniPadCustomXibPath: 
+  iOSDeviceRequirements: []
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -152,8 +172,10 @@ PlayerSettings:
   m_BuildTargetIcons:
   - m_BuildTarget: 
     m_Icons:
-    - m_Icon: {fileID: 2800000, guid: 181ee3ed40ace1e4280d4f264059c68d, type: 3}
-      m_Size: 128
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 181ee3ed40ace1e4280d4f264059c68d, type: 3}
+      m_Width: 128
+      m_Height: 128
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -237,6 +259,8 @@ PlayerSettings:
   ps4SdkOverride: 
   ps4BGMPath: 
   ps4ShareFilePath: 
+  ps4ShareOverlayImagePath: 
+  ps4PrivacyGuardImagePath: 
   ps4NPtitleDatPath: 
   ps4RemotePlayKeyAssignment: -1
   ps4RemotePlayKeyMappingDir: 
@@ -254,10 +278,18 @@ PlayerSettings:
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
   ps4ReprojectionSupport: 0
+  ps4UseAudio3dBackend: 0
+  ps4SocialScreenEnabled: 0
+  ps4Audio3dVirtualSpeakerCount: 14
+  ps4attribCpuUsage: 0
+  ps4PatchPkgPath: 
+  ps4PatchLatestPkgPath: 
+  ps4PatchChangeinfoPath: 
   ps4attribUserManagement: 0
   ps4attribMoveSupport: 0
   ps4attrib3DSupport: 0
   ps4attribShareSupport: 0
+  ps4IncludedModules: []
   monoEnv: 
   psp2Splashimage: {fileID: 0}
   psp2NPTrophyPackPath: 
@@ -309,10 +341,6 @@ PlayerSettings:
   spritePackerPolicy: 
   scriptingDefineSymbols: {}
   metroPackageName: Xbox360Input
-  metroPackageLogo: 
-  metroPackageLogo140: 
-  metroPackageLogo180: 
-  metroPackageLogo240: 
   metroPackageVersion: 
   metroCertificatePath: 
   metroCertificatePassword: 
@@ -320,44 +348,7 @@ PlayerSettings:
   metroCertificateIssuer: 
   metroCertificateNotAfter: 0000000000000000
   metroApplicationDescription: Xbox360Input
-  metroStoreTileLogo80: 
-  metroStoreTileLogo: 
-  metroStoreTileLogo140: 
-  metroStoreTileLogo180: 
-  metroStoreTileWideLogo80: 
-  metroStoreTileWideLogo: 
-  metroStoreTileWideLogo140: 
-  metroStoreTileWideLogo180: 
-  metroStoreTileSmallLogo80: 
-  metroStoreTileSmallLogo: 
-  metroStoreTileSmallLogo140: 
-  metroStoreTileSmallLogo180: 
-  metroStoreSmallTile80: 
-  metroStoreSmallTile: 
-  metroStoreSmallTile140: 
-  metroStoreSmallTile180: 
-  metroStoreLargeTile80: 
-  metroStoreLargeTile: 
-  metroStoreLargeTile140: 
-  metroStoreLargeTile180: 
-  metroStoreSplashScreenImage: 
-  metroStoreSplashScreenImage140: 
-  metroStoreSplashScreenImage180: 
-  metroPhoneAppIcon: 
-  metroPhoneAppIcon140: 
-  metroPhoneAppIcon240: 
-  metroPhoneSmallTile: 
-  metroPhoneSmallTile140: 
-  metroPhoneSmallTile240: 
-  metroPhoneMediumTile: 
-  metroPhoneMediumTile140: 
-  metroPhoneMediumTile240: 
-  metroPhoneWideTile: 
-  metroPhoneWideTile140: 
-  metroPhoneWideTile240: 
-  metroPhoneSplashScreenImage: 
-  metroPhoneSplashScreenImage140: 
-  metroPhoneSplashScreenImage240: 
+  wsaImages: {}
   metroTileShortName: 
   metroCommandLineArgsFile: 
   metroTileShowName: 0
@@ -467,7 +458,6 @@ PlayerSettings:
   WebGL::emscriptenArgs: 
   WebGL::template: APPLICATION:Default
   additionalIl2CppArgs::additionalIl2CppArgs: 
-  firstStreamedSceneWithResources: 0
   cloudProjectId: 
   projectName: 
   organizationId: 

--- a/XboxCtrlrInput/ProjectSettings/UnityConnectSettings.asset
+++ b/XboxCtrlrInput/ProjectSettings/UnityConnectSettings.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!310 &1
+UnityConnectSettings:
+  m_ObjectHideFlags: 0
+  UnityPurchasingSettings:
+    m_Enabled: 0
+    m_TestMode: 0
+  UnityAnalyticsSettings:
+    m_Enabled: 0
+    m_InitializeOnStartup: 1
+    m_TestMode: 0
+    m_TestEventUrl: 
+    m_TestConfigUrl: 


### PR DESCRIPTION
* Allow for DPad input be gotten via Button methods:  
DPadUp, DPadDown, DPadLeft and DPadRight have been added to the XboxButton enum.  
All Button methods now check if the passed button is a DPad direction, and if so, call and return the result of the appropiate DPad method.
This is a QoL change that keeps backwards compatibility and makes coding much easier in some situations.

* Use an enum for controller numbers:  
An enum now exists for controller numbers witch contains items First, Second, Third, Fourth and All. When calling a Button, DPad or Axis method and passing one of these values, the method first checks if the value is All and calls and returns the right method if so, otherwise it converts the value to an int and continues from there just like before.  
I believe this is a much superior system than what was in place before, but it does break backwards compatibility. It can be restored by overloading the methods and converting the given ints to values of the enum. I just can't be bothered to do this at the moment, but will do it later if needed.  
The example room has been updated to work with this change.

* Fix some wrong documentation:  
Some methods that took only one argument were documented as taking two. I removed the extra, wrong documentation.

Admittedly I didn't test this much, but it should work fine.

Note that I've used Unity 5.3.1f1 to make these changes, I don't know if that could be a problem.